### PR TITLE
Update build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ archivesBaseName = 'qupath-fxtras'
 description = "Extra classes built on JavaFX that are used to help create the QuPath user interface. " +
         "These don't depend on other QuPath modules, so can be reused elsewhere."
 
+group = 'io.github.qupath'
 version = '0.1.0-SNAPSHOT'
 
 tasks.named('compileJava') {
@@ -116,7 +117,6 @@ publishing {
 
     publications {
         mavenJava(MavenPublication) {
-            groupId = 'io.github.qupath'
             from components.java
 
             pom {


### PR DESCRIPTION
Specify `group` separately - attempts to resolve problem with the `group` messing from the Gradle module metadata json, which led to
```
missing 'group' at /variants[4]/capabilities[0]
```
exceptions when trying to use the artifact.