### PR TITLE
Support reformatting strings in the PropertyEditorFactory

### DIFF
--- a/src/main/java/qupath/fx/prefs/controlsfx/PropertyEditorFactory.java
+++ b/src/main/java/qupath/fx/prefs/controlsfx/PropertyEditorFactory.java
@@ -34,6 +34,7 @@ import qupath.fx.prefs.controlsfx.items.PropertyItem;
 import qupath.fx.utils.FXUtils;
 
 import java.io.File;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
@@ -49,7 +50,7 @@ public class PropertyEditorFactory extends DefaultPropertyEditorFactory {
      * We may wish to reformat the display of some types, e.g. enums that are
      * otherwise shown with all capitals.
      */
-    private Map<Class<?>, Function<?, String>> reformatTypes = Map.of();
+    private Map<Class<?>, Function<?, String>> reformatTypes = new HashMap<>();
 
     /**
      * A default reformatter that can be used to show enums in a nicer way
@@ -131,12 +132,13 @@ public class PropertyEditorFactory extends DefaultPropertyEditorFactory {
     }
 
     /**
-     * Request that editors created with this factory reformat the default string display of the specified enum
+     * Request that editors created with this factory reformat the default string display of the specified enums
      * using the default reformatting method.
-     * @param cls
+     * @param enumTypes
      */
-    public void setReformatEnum(Class<? extends Enum> cls) {
-        setReformatType(cls, ENUM_REFORMATTER);
+    public void setReformatEnums(Class<? extends Enum>... enumTypes) {
+        for (var cls : enumTypes)
+            setReformatType(cls, ENUM_REFORMATTER);
     }
 
     /**

--- a/src/main/java/qupath/fx/prefs/controlsfx/PropertyItemParser.java
+++ b/src/main/java/qupath/fx/prefs/controlsfx/PropertyItemParser.java
@@ -37,6 +37,7 @@ import qupath.fx.prefs.annotations.PrefCategory;
 import qupath.fx.prefs.annotations.StringPref;
 import qupath.fx.prefs.controlsfx.items.PropertyItem;
 
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -101,7 +102,7 @@ public class PropertyItemParser {
         }
 
         for (var field : cls.getDeclaredFields()) {
-            if (!field.canAccess(obj) || !Property.class.isAssignableFrom(field.getType()))
+            if (Modifier.isStatic(field.getModifiers()) || !field.canAccess(obj) || !Property.class.isAssignableFrom(field.getType()))
                 continue;
             PropertySheet.Item item = null;
             try {

--- a/src/main/java/qupath/fx/prefs/controlsfx/PropertySheetBuilder.java
+++ b/src/main/java/qupath/fx/prefs/controlsfx/PropertySheetBuilder.java
@@ -16,7 +16,9 @@
 
 package qupath.fx.prefs.controlsfx;
 
+import javafx.util.Callback;
 import org.controlsfx.control.PropertySheet;
+import org.controlsfx.property.editor.PropertyEditor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import qupath.fx.prefs.annotations.ColorPref;
@@ -57,6 +59,16 @@ public class PropertySheetBuilder {
      */
     public PropertySheetBuilder parser(PropertyItemParser parser) {
         this.parser = parser;
+        return this;
+    }
+
+    /**
+     * Set the property editor factory to use.
+     * @param factory
+     * @return this builder
+     */
+    public PropertySheetBuilder editorFactory(Callback<PropertySheet.Item, PropertyEditor<?>> factory) {
+        this.sheet.setPropertyEditorFactory(factory);
         return this;
     }
 


### PR DESCRIPTION
This can be used to make `LOUD_ENUMS` becomes less `Loud enums`