### PR TITLE
Fix directory editor

### DIFF
--- a/src/main/java/qupath/fx/prefs/controlsfx/PropertyEditorFactory.java
+++ b/src/main/java/qupath/fx/prefs/controlsfx/PropertyEditorFactory.java
@@ -79,7 +79,7 @@ public class PropertyEditorFactory extends DefaultPropertyEditorFactory {
             return editor;
 
         if (item.getType() == File.class) {
-            editor = new DirectoryEditor(item, new TextField());
+            editor = new DirectoryEditor(item);
         } else if (item instanceof ChoicePropertyItem) {
             var choiceItem = ((ChoicePropertyItem<?>)item);
             if (choiceItem.makeSearchable()) {

--- a/src/main/java/qupath/fx/prefs/controlsfx/editors/DirectoryEditor.java
+++ b/src/main/java/qupath/fx/prefs/controlsfx/editors/DirectoryEditor.java
@@ -17,14 +17,24 @@
 package qupath.fx.prefs.controlsfx.editors;
 
 import javafx.beans.binding.Bindings;
-import javafx.beans.property.Property;
 import javafx.beans.value.ObservableValue;
+import javafx.geometry.Pos;
+import javafx.scene.Node;
+import javafx.scene.control.Button;
+import javafx.scene.control.ContentDisplay;
 import javafx.scene.control.TextField;
 import javafx.scene.control.Tooltip;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
+import javafx.scene.text.TextAlignment;
 import javafx.util.Duration;
 import org.controlsfx.control.PropertySheet;
+import org.controlsfx.glyphfont.FontAwesome;
+import org.controlsfx.glyphfont.Glyph;
+import org.controlsfx.glyphfont.GlyphFontRegistry;
 import org.controlsfx.property.editor.AbstractPropertyEditor;
 import qupath.fx.dialogs.FileChoosers;
+import qupath.fx.localization.LocalizedResourceManager;
 import qupath.fx.prefs.controlsfx.items.DirectoryPropertyItem;
 
 import java.io.File;
@@ -32,52 +42,133 @@ import java.io.File;
 /**
  * Editor for selecting directory paths.
  *
- * Appears as a text field that can be double-clicked to launch a directory chooser.
+ * Appears as a text field with associated button to launch a directory chooser.
  */
-public class DirectoryEditor extends AbstractPropertyEditor<File, TextField> {
+public class DirectoryEditor extends AbstractPropertyEditor<File, DirectoryEditor.DirectoryChoiceControl> {
 
-    private ObservableValue<File> value;
+    public DirectoryEditor(PropertySheet.Item property) {
+        super(property, new DirectoryChoiceControl(), true);
+        configureTooltip();
+        // TODO: Consider using listeners & paying attention to focus to avoid repeated calls
+        //       when the user is entering text, but it is not yet a valid directory
+        if (getProperty() instanceof DirectoryPropertyItem prop) {
+            getEditor().getTextField().textProperty().bindBidirectional(prop.getDirectoryPathProperty());
+        }
+    }
 
-    public DirectoryEditor(PropertySheet.Item property, TextField control) {
-        super(property, control, true);
-        control.setOnMouseClicked(e -> {
-            if (e.getClickCount() > 1) {
-                e.consume();
-                File dirNew = FileChoosers.promptForDirectory(control.getScene().getWindow(), null, getValue());
-                if (dirNew != null)
-                    setValue(dirNew);
-            }
-        });
+    private void configureTooltip() {
+        var control = getEditor();
+        var property = getProperty();
         if (property.getDescription() != null) {
             var description = property.getDescription();
             var tooltip = new Tooltip(description);
             tooltip.setShowDuration(Duration.millis(10_000));
-            control.setTooltip(tooltip);
+            Tooltip.install(control, tooltip);
         }
-
-        // Bind to the text property
-        if (property instanceof DirectoryPropertyItem) {
-            var prop = property.getObservableValue().orElse(null);
-            if (prop instanceof Property)
-                control.textProperty().bindBidirectional((Property<String>)prop);
-        }
-        value = Bindings.createObjectBinding(() -> {
-            String text = control.getText();
-            if (text == null || text.trim().isEmpty() || !new File(text).isDirectory())
-                return null;
-            else
-                return new File(text);
-        }, control.textProperty());
     }
 
     @Override
     public void setValue(File value) {
-        getEditor().setText(value == null ? null : value.getAbsolutePath());
+        getEditor().getTextField().setText(value == null ? null : value.getAbsolutePath());
     }
 
     @Override
     protected ObservableValue<File> getObservableValue() {
-        return value;
+        return getEditor().getObservableFile();
+    }
+
+    /**
+     * Simple control to input a directory path, or choose from a directory chooser.
+     */
+    public static class DirectoryChoiceControl extends HBox {
+
+        private static LocalizedResourceManager resources = LocalizedResourceManager.createInstance("qupath.fx.localization.strings");
+
+        private TextField textField = new TextField();
+        private Button button = new Button();
+
+        private ObservableValue<File> value;
+
+        private DirectoryChoiceControl() {
+            button = createButton();
+            textField = createTextField();
+            configureButton();
+            configureTextField();
+            setSpacing(5.0);
+            getChildren().addAll(textField, button);
+        }
+
+        private Button createButton() {
+            var button = new Button();
+            button.setMaxWidth(Double.MAX_VALUE);
+            button.setMaxHeight(Double.MAX_VALUE);
+            button.setGraphic(createIcon(12));
+            var tooltip = new Tooltip();
+            tooltip.textProperty().bind(
+                    resources.createProperty("chooseDirectory")
+            );
+            return button;
+        }
+
+        private void configureButton() {
+            var button = getButton();
+            button.setOnAction(e -> {
+                File dirNew = FileChoosers.promptForDirectory(button.getScene().getWindow(), null, getObservableFile().getValue());
+                if (dirNew != null)
+                    textField.textProperty().set(dirNew.getAbsolutePath());
+                e.consume();
+            });
+        }
+
+        private TextField createTextField() {
+            var textField = new TextField();
+            textField.setMaxWidth(Double.MAX_VALUE);
+            HBox.setHgrow(textField, Priority.ALWAYS);
+            return textField;
+        }
+
+        private void configureTextField() {
+            // Bind to the text property
+            var textProperty = textField.textProperty();
+            value = Bindings.createObjectBinding(() -> {
+                String text = textProperty.get();
+                if (text == null || text.trim().isEmpty() || !new File(text).isDirectory())
+                    return null;
+                else
+                    return new File(text);
+            }, textProperty);
+        }
+
+        private ObservableValue<File> getObservableFile() {
+            return value;
+        }
+
+        /**
+         * Get the text field to edit the directory path.
+         * @return
+         */
+        public TextField getTextField() {
+            return textField;
+        }
+
+        /**
+         * Get the button to open a directory chooser.
+         * @return
+         */
+        public Button getButton() {
+            return button;
+        }
+
+        private Node createIcon(int size) {
+            var font = GlyphFontRegistry.font("FontAwesome");
+            Glyph g = font.create(FontAwesome.Glyph.FOLDER_OPEN_ALT).size(size);
+            g.setAlignment(Pos.CENTER);
+            g.setContentDisplay(ContentDisplay.CENTER);
+            g.setTextAlignment(TextAlignment.CENTER);
+            g.setStyle("-fx-text-fill: -fx-text-base-color;");
+            return g;
+        }
+
     }
 
 }

--- a/src/main/java/qupath/fx/prefs/controlsfx/items/DirectoryPropertyItem.java
+++ b/src/main/java/qupath/fx/prefs/controlsfx/items/DirectoryPropertyItem.java
@@ -18,6 +18,7 @@ package qupath.fx.prefs.controlsfx.items;
 
 import javafx.beans.binding.Bindings;
 import javafx.beans.property.Property;
+import javafx.beans.property.StringProperty;
 import javafx.beans.value.ObservableValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,6 +63,16 @@ public class DirectoryPropertyItem extends PropertyItem {
             prop.setValue(null);
         else
             logger.error("Cannot set property {} with value {}", prop, value);
+    }
+
+    /**
+     * Get the string property that represents the directory.
+     * This may be more useful for editors that want to bind to the text property.
+     * No check is made to ensure that the path is valid.
+     * @return
+     */
+    public Property<String> getDirectoryPathProperty() {
+        return prop;
     }
 
     @Override


### PR DESCRIPTION
Fix broken directory editor for preferences (using a ControlsFX PropertySheet), and add a button to select the directory rather than relying on a double-click of the text field.