### PR TITLE
Support prompt text with pref properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.1.3
+- Support prompt text for preferences using text fields or combo boxes
+  - Use 'key + .prompt' within resource bundles
+
 ## v0.1.2
 - Support `File` preferences (not only directories)
 

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ description = "Extra classes built on JavaFX that are used to help create the Qu
         "These don't depend on other QuPath modules, so can be reused elsewhere."
 
 group = 'io.github.qupath'
-version = '0.1.2'
+version = '0.1.3-SNAPSHOT'
 
 tasks.named('compileJava') {
     // Use the project's version or define one directly

--- a/src/main/java/qupath/fx/prefs/controlsfx/PropertyEditorFactory.java
+++ b/src/main/java/qupath/fx/prefs/controlsfx/PropertyEditorFactory.java
@@ -21,6 +21,7 @@ import javafx.beans.value.ObservableValue;
 import javafx.scene.Node;
 import javafx.scene.Parent;
 import javafx.scene.control.ComboBox;
+import javafx.scene.control.ComboBoxBase;
 import javafx.scene.control.Label;
 import javafx.scene.control.TextField;
 import javafx.stage.FileChooser;
@@ -107,6 +108,18 @@ public class PropertyEditorFactory extends DefaultPropertyEditorFactory {
             combo.setCellFactory(obj -> FXUtils.createCustomListCell(formatter));
             combo.setButtonCell(FXUtils.createCustomListCell(formatter));
         }
+
+        // Handle prompt text, if necessary
+        if (item instanceof PropertyItem propItem) {
+            if (editor.getEditor() instanceof TextField tf) {
+                if (!tf.promptTextProperty().isBound())
+                    tf.promptTextProperty().bindBidirectional(propItem.promptProperty());
+            } else if (editor.getEditor() instanceof ComboBoxBase<?> combo) {
+                if (!combo.promptTextProperty().isBound())
+                    combo.promptTextProperty().bindBidirectional(propItem.promptProperty());
+            }
+        }
+
 
 //        // Make it easier to reset default locale
 //        if (Locale.class.equals(item.getType())) {

--- a/src/main/java/qupath/fx/prefs/controlsfx/PropertyItemParser.java
+++ b/src/main/java/qupath/fx/prefs/controlsfx/PropertyItemParser.java
@@ -169,6 +169,7 @@ public class PropertyItemParser {
             var cls = parent.getClass();
             try {
                 var method = cls.getDeclaredMethod(choiceMethod);
+                method.setAccessible(true);
                 var result = method.invoke(parent);
                 if (result instanceof ObservableList list) {
                     builder.choices(list);

--- a/src/main/java/qupath/fx/prefs/controlsfx/editors/AbstractChoiceEditor.java
+++ b/src/main/java/qupath/fx/prefs/controlsfx/editors/AbstractChoiceEditor.java
@@ -26,6 +26,7 @@ import org.controlsfx.control.PropertySheet;
 import org.controlsfx.property.editor.AbstractPropertyEditor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import qupath.fx.prefs.controlsfx.items.PropertyItem;
 import qupath.fx.utils.converters.LocaleConverter;
 
 import java.util.Locale;
@@ -40,6 +41,9 @@ abstract class AbstractChoiceEditor<T, S extends ComboBox<T>> extends AbstractPr
         super(property, combo);
         if (property.getType().equals(Locale.class)) {
             combo.setConverter((StringConverter<T>)new LocaleConverter());
+        }
+        if (property instanceof PropertyItem item) {
+            combo.promptTextProperty().bind(item.promptProperty());
         }
         this.choices = choices == null ? FXCollections.observableArrayList() : choices;
         combo.getItems().setAll(this.choices);

--- a/src/main/java/qupath/fx/prefs/controlsfx/editors/AbstractFileEditor.java
+++ b/src/main/java/qupath/fx/prefs/controlsfx/editors/AbstractFileEditor.java
@@ -36,7 +36,9 @@ import org.controlsfx.glyphfont.GlyphFontRegistry;
 import org.controlsfx.property.editor.AbstractPropertyEditor;
 import qupath.fx.dialogs.FileChoosers;
 import qupath.fx.localization.LocalizedResourceManager;
+import qupath.fx.prefs.controlsfx.items.DirectoryPropertyItem;
 import qupath.fx.prefs.controlsfx.items.FilePropertyItem;
+import qupath.fx.prefs.controlsfx.items.PropertyItem;
 
 import java.io.File;
 import java.util.Collection;
@@ -64,8 +66,14 @@ abstract class AbstractFileEditor extends AbstractPropertyEditor<File, Directory
         // TODO: Consider using listeners & paying attention to focus to avoid repeated calls
         //       when the user is entering text, but it is not yet a valid file or directory
         if (getProperty() instanceof FilePropertyItem prop) {
-            getEditor().getTextField().textProperty().bindBidirectional(prop.getFilePathProperty());
+            var tf = getEditor().getTextField();
+            tf.textProperty().bindBidirectional(prop.getFilePathProperty());
+        } else if (getProperty() instanceof DirectoryPropertyItem prop) {
+            var tf = getEditor().getTextField();
+            tf.textProperty().bindBidirectional(prop.getFilePathProperty());
         }
+        if (getProperty() instanceof PropertyItem prop)
+            getEditor().getTextField().promptTextProperty().bind(prop.promptProperty());
     }
 
     private void configureTooltip() {

--- a/src/main/java/qupath/fx/prefs/controlsfx/items/PropertyItem.java
+++ b/src/main/java/qupath/fx/prefs/controlsfx/items/PropertyItem.java
@@ -33,6 +33,7 @@ public abstract class PropertyItem implements PropertySheet.Item {
     private final StringProperty name = new SimpleStringProperty();
     private final StringProperty category = new SimpleStringProperty();
     private final StringProperty description = new SimpleStringProperty();
+    private final StringProperty prompt = new SimpleStringProperty();
 
     PropertyItem(LocalizedResourceManager manager) {
         this.manager = manager == null ? DEFAULT_MANAGER : manager;
@@ -76,12 +77,23 @@ public abstract class PropertyItem implements PropertySheet.Item {
         return this.description;
     }
 
+    /**
+     * Optional prompt property, which can be displayed in empty text fields.
+     * Obtained from the resource bundle using the key {@code key + ".prompt"}.
+     * @return
+     */
+    public StringProperty promptProperty() {
+        return this.prompt;
+    }
+
     public PropertyItem key(String bundle, String key) {
         if (bundle != null && bundle.isBlank())
             bundle = null;
         manager.registerProperty(name, bundle, key);
         if (manager.hasString(bundle, key + ".description"))
             manager.registerProperty(description, bundle, key + ".description");
+        if (manager.hasString(bundle, key + ".prompt"))
+            manager.registerProperty(prompt, bundle, key + ".prompt");
         return this;
     }
 


### PR DESCRIPTION
Use `key + ".prompt"` in resource bundles.
This makes it possible to show useful prompts in text fields or combo boxes if needed.