### PR TITLE
Add javadoc action

### DIFF
--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -1,10 +1,12 @@
 name: Build and Publish Javadocs
 
+
 on:
   push:
     branches:
       - main
-      - '*'
+    tags:
+      - v*
 
 jobs:
   build-and-publish-javadocs:

--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -27,6 +27,7 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          # fake ternary, see https://github.com/orgs/community/discussions/26738#discussioncomment-3253176
           destination_dir: ${{ github.ref == 'refs/heads/main' && 'latest' || github.ref_name }}
           publish_dir: ./build/docs/javadoc
           publish_branch: gh-pages

--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -1,0 +1,32 @@
+name: Build and Publish Javadocs
+
+on:
+  push:
+    branches:
+      - main
+      - '*'
+
+jobs:
+  build-and-publish-javadocs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Build Javadocs
+        run: ./gradlew javadoc
+
+      - name: Publish Javadocs to gh-pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          destination_dir: ${{ github.ref == 'refs/heads/main' && 'latest' || github.ref }}
+          publish_dir: ./build/docs/javadoc
+          publish_branch: gh-pages
+          allow_empty_commit: true

--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -1,6 +1,5 @@
 name: Build and Publish Javadocs
 
-
 on:
   push:
     branches:
@@ -32,3 +31,22 @@ jobs:
           publish_dir: ./build/docs/javadoc
           publish_branch: gh-pages
           allow_empty_commit: true
+
+  update-symlink:
+    needs: build-and-publish-javadocs
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          ref: gh-pages
+      - name: Update stable symlink
+        run: |
+          rm stable
+          ln -s ${{ github.ref_name }} stable
+          git config --local user.email "actions@github.com"
+          git config --local user.name "GitHub Actions"
+          git add stable
+          git commit -m "Update stable symlink to ${{ github.ref_name }}"
+          git push origin gh-pages

--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -27,7 +27,7 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          destination_dir: ${{ github.ref == 'refs/heads/main' && 'latest' || github.ref }}
+          destination_dir: ${{ github.ref == 'refs/heads/main' && 'latest' || github.ref_name }}
           publish_dir: ./build/docs/javadoc
           publish_branch: gh-pages
           allow_empty_commit: true

--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up JDK
         uses: actions/setup-java@v4
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: gh-pages
       - name: Update stable symlink


### PR DESCRIPTION
This builds javadoc on main and publishes it to the latest subdir

vX.Y tags also get built and published to a tag subdirectory

The top level index points to `stable/index.html`, and `stable` is a symlink pointing to a tag subdirectory. Currently 0.1.4.

I've only published the 0.1.4, I was gonna build the rest but seems pointless for now.

For new tags, the second job in the action updates the `stable` link to point to the docs for the current tag. Maybe a problem if we ever publish versions out of order (eg we publish 0.6.0, but find a critical bug in 0.5.3 so publish 0.5.4), but we shouldn't do that often, so I think it's fine

Output is here: https://alanocallaghan.github.io/qupath-fxtras

Absolutely not merging this on a Friday at 5pm, so will revisit next week and probably update https://github.com/qupath/javadoc/ as well... or maybe scrap this and try to do a big merged javadoc. Will see
