### PR TITLE
Correct perm scope

### DIFF
--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -11,6 +11,7 @@ jobs:
   build-and-publish-javadocs:
     permissions:
       pages: write
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -38,6 +39,7 @@ jobs:
   update-symlink:
     permissions:
       pages: write
+      contents: write
     needs: build-and-publish-javadocs
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest


### PR DESCRIPTION
I guess pushing to gh-pages is writing content, not writing to pages, which makes sense (?)