### PR TITLE
When setting the height of an undocked pane window, use prefHeight instead of getHeight

### DIFF
--- a/src/main/java/qupath/fx/utils/FXUtils.java
+++ b/src/main/java/qupath/fx/utils/FXUtils.java
@@ -228,7 +228,7 @@ public class FXUtils {
         var parent = tabPane.getScene() == null ? null : tabPane.getScene().getWindow();
 
         double width = tabPane.getWidth();
-        double height = tabPane.getHeight();
+        double height = tabPane.prefHeight(-1);
         tabPane.getTabs().remove(tab);
         var stage = new Stage();
         stage.initOwner(parent);


### PR DESCRIPTION
This is to correct an issue I had when undocking panes in a maximized QuPath, through an RDP session, when the client window's size is significantly smaller than that of the remote desktop's.

I *think* Windows (10-11) gets confused with RDP sessions and reports the height of the native remote desktop instead of the height of the RDP client. At least what happens for me is that after undocking, the pane-dialogs can be so tall that the window header is outside the screen, making them tricky to resize (at least in Windows).

Another benefit I think, is that using prefHeight makes prettier dialogs (my very own opinion).

Undocking all the panes in a recent QuPath 0.6-SNAPSHOT, this is what the result looks like with my code change applied:
![image](https://github.com/user-attachments/assets/5b7c620c-d65a-4ca0-9d80-974651ba2288)

I was only able to test this modification locally on my Windows desktop, but not yet remotely, or in Linux or in MacOSX (that unfortunately won't be easy for me to test).

I will do some more testing and report back.

Cheers,
Egor