### PR TITLE
Improve error notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v0.1.5
 - Improve behavior of `FXUtils.installSelectAllOrNoneMenu` (https://github.com/qupath/qupath/issues/1498)
 - New `FXUtils.addCloseWindowShortcuts` methods to enable closing windows from the keyboard
+- Improve error notifications when there is no associated text
 
 ## v0.1.4
 - Make yes/no/cancel dialog non-resizable, for consistency (https://github.com/qupath/qupath-fxtras/issues/26)

--- a/src/main/java/qupath/fx/dialogs/Dialogs.java
+++ b/src/main/java/qupath/fx/dialogs/Dialogs.java
@@ -331,8 +331,11 @@ public class Dialogs {
 				logger.error(title + ": " + e.getLocalizedMessage(), e);
 			else
 				logger.error(title , e);
-		} else
+		} else {
+			if (message == null || message.isBlank())
+				message = "Unknown error (" + e.getClass().getSimpleName() + ")";
 			showNotification(title, message, AlertType.ERROR);
+		}
 	}
 
 	/**


### PR DESCRIPTION
This can be seen in a QuPath script:
```groovy
Platform.runLater {
    throw new RuntimeException()
}
```
Previously, a blank error notification would appear with no text.
Now it reports an unknown error, and provides the type of the exception.
