### PR TITLE
Alanocallaghan patch 2

### DIFF
--- a/src/main/java/qupath/fx/dialogs/FileChoosers.java
+++ b/src/main/java/qupath/fx/dialogs/FileChoosers.java
@@ -327,7 +327,7 @@ public class FileChoosers {
     /**
      * Convenience method to create a {@link javafx.stage.FileChooser.ExtensionFilter} instance
      * from a description and array of extensions.
-     * This checks to ensure that the provided extensions start with {@code ".*"}, and appends
+     * This checks to ensure that the provided extensions start with {@code "*."}, and appends
      * one or both characters if necessary.
      * @param description description of the filter
      * @param extensions file extensions associated with the filter
@@ -340,7 +340,7 @@ public class FileChoosers {
     /**
      * Convenience method to create a {@link javafx.stage.FileChooser.ExtensionFilter} instance
      * from a description and collection of extensions.
-     * This checks to ensure that the provided extensions start with {@code ".*"}, and appends
+     * This checks to ensure that the provided extensions start with {@code "*."}, and appends
      * one or both characters if necessary.
      * @param description
      * @param extensions

--- a/src/main/java/qupath/fx/localization/LocalizedResourceManager.java
+++ b/src/main/java/qupath/fx/localization/LocalizedResourceManager.java
@@ -104,7 +104,7 @@ public class LocalizedResourceManager {
 	public boolean hasString(String key) {
 		if (defaultBundleName == null)
 			return false;
-		return hasString(defaultBundleName);
+		return hasString(defaultBundleName, key);
 	}
 
 	/**

--- a/src/main/java/qupath/fx/localization/LocalizedResourceManager.java
+++ b/src/main/java/qupath/fx/localization/LocalizedResourceManager.java
@@ -104,7 +104,7 @@ public class LocalizedResourceManager {
 	public boolean hasString(String key) {
 		if (defaultBundleName == null)
 			return false;
-		return hasString(defaultBundleName, key);
+		return hasString(defaultBundleName);
 	}
 
 	/**


### PR DESCRIPTION
There's a semantic difference (in Unix at least) between `.*` (any character any amount of times) and `*.` (a glob for anything followed by a literal dot).

Also, using `.*.yaml` will not produce a useful filechooser
