### PR TITLE
Improve screen choice for input display

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ description = "Extra classes built on JavaFX that are used to help create the Qu
         "These don't depend on other QuPath modules, so can be reused elsewhere."
 
 group = 'io.github.qupath'
-version = '0.1.6'
+version = '0.1.7-SNAPSHOT'
 
 tasks.named('compileJava') {
     // Use the project's version or define one directly

--- a/src/main/java/qupath/fx/controls/InputDisplay.java
+++ b/src/main/java/qupath/fx/controls/InputDisplay.java
@@ -65,21 +65,21 @@ public class InputDisplay implements EventHandler<InputEvent> {
 	private static final Logger logger = LoggerFactory.getLogger(InputDisplay.class);
 
 	// Owner window (for stage positioning)
-	private Window owner;
+	private final Window owner;
 
 	// All windows to listen to
-	private ObservableList<? extends Window> allWindows;
+	private final ObservableList<? extends Window> allWindows;
 
-	private BooleanProperty showProperty = new SimpleBooleanProperty(false);
+	private final BooleanProperty showProperty = new SimpleBooleanProperty(false);
 
-	private BooleanProperty showCloseButton = new SimpleBooleanProperty(true);
+	private final BooleanProperty showCloseButton = new SimpleBooleanProperty(true);
 
 	private Stage stage;
 
-	private FocusListener focusListener = new FocusListener();
-	private KeyFilter keyFilter = new KeyFilter();
-	private MouseFilter mouseFilter = new MouseFilter();
-	private ScrollFilter scrollFilter = new ScrollFilter();
+	private final FocusListener focusListener = new FocusListener();
+	private final KeyFilter keyFilter = new KeyFilter();
+	private final MouseFilter mouseFilter = new MouseFilter();
+	private final ScrollFilter scrollFilter = new ScrollFilter();
 
 	private static final String inputDisplayClass = "input-display-pane";
 	private static final String closeItemClass = "close-item";
@@ -87,23 +87,23 @@ public class InputDisplay implements EventHandler<InputEvent> {
 	private static final PseudoClass pseudoClassActive = PseudoClass.getPseudoClass("active");
 
 	// Keys
-	private Set<KeyCode> MODIFIER_KEYS = Set.of(
+	private final Set<KeyCode> MODIFIER_KEYS = Set.of(
 			KeyCode.SHIFT, KeyCode.SHORTCUT, KeyCode.COMMAND, KeyCode.CONTROL, KeyCode.ALT, KeyCode.ALT_GRAPH
 	);
 
-	private ObservableMap<String, String> modifiers = FXCollections.observableMap(new TreeMap<>());
-	private ObservableMap<String, String> keys = FXCollections.observableMap(new TreeMap<>());
+	private final ObservableMap<String, String> modifiers = FXCollections.observableMap(new TreeMap<>());
+	private final ObservableMap<String, String> keys = FXCollections.observableMap(new TreeMap<>());
 
 	// Buttons
-	private BooleanProperty primaryDown = new SimpleBooleanProperty(false);
-	private BooleanProperty secondaryDown = new SimpleBooleanProperty(false);
-	private BooleanProperty middleDown = new SimpleBooleanProperty(false);
+	private final BooleanProperty primaryDown = new SimpleBooleanProperty(false);
+	private final BooleanProperty secondaryDown = new SimpleBooleanProperty(false);
+	private final BooleanProperty middleDown = new SimpleBooleanProperty(false);
 
 	// Scroll/wheel
-	private BooleanProperty scrollLeft = new SimpleBooleanProperty(false);
-	private BooleanProperty scrollRight = new SimpleBooleanProperty(false);
-	private BooleanProperty scrollUp = new SimpleBooleanProperty(false);
-	private BooleanProperty scrollDown = new SimpleBooleanProperty(false);
+	private final BooleanProperty scrollLeft = new SimpleBooleanProperty(false);
+	private final BooleanProperty scrollRight = new SimpleBooleanProperty(false);
+	private final BooleanProperty scrollUp = new SimpleBooleanProperty(false);
+	private final BooleanProperty scrollDown = new SimpleBooleanProperty(false);
 
 	/**
 	 * Create an input display with the specified owner window.
@@ -211,8 +211,9 @@ public class InputDisplay implements EventHandler<InputEvent> {
 		closeButton.visibleProperty().bind(showCloseButton);
 
 
-		// Set default location as the bottom left corner of the primary screen
-		var screenBounds = Screen.getPrimary().getVisualBounds();
+		// Set default location as the bottom left corner of the screen
+		Screen screen = owner == null ? Screen.getPrimary() : FXUtils.getScreenOrPrimary(owner);
+		var screenBounds = screen.getVisualBounds();
 		double xPad = 10;
 		double yPad = 10;
 

--- a/src/main/java/qupath/fx/utils/FXUtils.java
+++ b/src/main/java/qupath/fx/utils/FXUtils.java
@@ -143,11 +143,27 @@ public class FXUtils {
     /**
      * Get the screen that contains a window, or null if no screen contains the window.
      * If the window spans across multiple screens, then the one with the largest overlap will be returned.
-     * @param window
-     * @return
+     * @param window the window to check
+     * @return the screen containing the window, or null if no screen could be found
+     * @see #getScreenOrPrimary(Window)
      */
     public static Screen getScreen(Window window) {
-        return getMaxOverlapScreen(window.getX(), window.getY(), window.getWidth(), window.getHeight());
+        if (window == null) {
+            return null;
+        } else {
+            return getMaxOverlapScreen(window.getX(), window.getY(), window.getWidth(), window.getHeight());
+        }
+    }
+
+    /**
+     * Get the screen that contains a window, or the primary screen if no screen contains the window.
+     * @param window the window to check
+     * @return the screen containing the window, or primary screen if no other screen could be found
+     * @see #getScreen(Window)
+     */
+    public static Screen getScreenOrPrimary(Window window) {
+        var screen = getScreen(window);
+        return screen == null ? Screen.getPrimary() : screen;
     }
 
     /**


### PR DESCRIPTION
Using the primary screen could be problematic when using multiple displays - now use the screen containing the owner window instead.