### PR TITLE
relaxed localeFilter to allow country code modifiers through

### DIFF
--- a/src/main/java/qupath/fx/localization/LocaleManager.java
+++ b/src/main/java/qupath/fx/localization/LocaleManager.java
@@ -95,7 +95,7 @@ public class LocaleManager {
     private boolean localeFilter(Locale locale) {
         if (Objects.equals(locale, baseLocale))
             return true;
-        return !locale.getLanguage().isBlank() && locale.getCountry().isEmpty() && locale != Locale.ENGLISH;
+        return !locale.getLanguage().isBlank() && locale != Locale.ENGLISH;
     }
 
     /**


### PR DESCRIPTION
This is to allow the detection of localized resource files that have a country code modifier in their locale.

For example, `qupath-gui-strings_pt_PT.properties` and `qupath-gui-strings_pt_BR.properties` will now be properly detected, whereas before, only `qupath-gui-strings_pt.properties` was.

I've checked this change on both Windows 10 and Linux Mint 22.1. The extra files let through the `localeFilter` function do not introduce any noticeable slow down in `localeManager.refreshAvailableLocales()`.

I discussed the result of this change and published a couple of screenshots on the image.sc forum: https://forum.image.sc/t/qupath-localization-again/111966/2

Cheers,
Egor