### PR TITLE
Improve file chooser behavior

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 base {
     group = "io.github.qupath"
-    version = "0.2.0-rc1"
+    version = "0.2.0-rc2"
     description = "Extra classes built on JavaFX that are used to help create the QuPath user interface. " +
             "These don't depend on other QuPath modules, so can be reused elsewhere."
 }


### PR DESCRIPTION
This attempts to improve the behavior of file save dialogs when using multi-part extensions, e.g. .ome.tif or .ome.zarr.

Previously, these could act strangely - giving odd default filename such as "Untitled.ome.zarr.zarr", and attempts to correct the behavior didn't always work.

This tries to make a better attempt to work around attempts from JavaFX/the OS to thwart the use of multi-part extensions.

One way to test it in QuPath is with the following scripts:

```groovy
for (var ext : ["*.txt", "*.tif", "*.ome.tif", "*.zarr", "*.ome.zarr", "*.*"]) {
    var filter = FileChoosers.createExtensionFilter("A filter", ext);
    var fileNoInitial = FileChoosers.promptToSaveFile(
            "Some title",
            null,
            filter
    )

    var fileNameOnly = FileChoosers.promptToSaveFile(
            "Some title",
            new File("Named"),
            filter
    )

    var fileNameAndExt = FileChoosers.promptToSaveFile(
            "Some title",
            new File("Full" + ext.substring(1)),
            filter
    )
    
    println("Extension: " + ext)
    println("--" + fileNoInitial)
    println("--" + fileNameOnly)
    println("--" + fileNameAndExt)
}
```
Accepting all the proposed names, in QuPath v0.6.0-rc5 and earlier I was ending up with `Untitled.ome.tif`, `Untitled.zarr.zarr` and `Untitled.ome.zarr.ome.zarr` on MacOS. With this PR, all the names contain the expected extension only once (even if they aren't *always* shown as expected in the dialog).