### PR TITLE
Optionally add close shortcuts to dialogs

### DIFF
--- a/src/main/java/qupath/fx/dialogs/Dialogs.java
+++ b/src/main/java/qupath/fx/dialogs/Dialogs.java
@@ -16,6 +16,7 @@
 
 package qupath.fx.dialogs;
 
+import java.util.Set;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.stage.PopupWindow;
@@ -572,6 +573,7 @@ public class Dialogs {
 		private double prefHeight = -1;
 		private List<ButtonType> buttons = null;
 		private Modality modality = Modality.APPLICATION_MODAL;
+		private Boolean addCloseShortcuts = null;
 		
 		/**
 		 * Specify the dialog title.
@@ -645,6 +647,28 @@ public class Dialogs {
 		 */
 		public Builder resizable() {
 			resizable = true;
+			return this;
+		}
+
+		/**
+		 * Request that the dialog can be easily closed by shortcut keys, including Ctrl+W.
+		 * @return this builder
+		 * @see #closeShortcuts(boolean)
+		 */
+		public Builder closeShortcuts() {
+			return closeShortcuts(true);
+		}
+
+		/**
+		 * Optionally request that the dialog can be easily closed by shortcut keys, including Ctrl+W.
+		 * @param addShortcuts true if shortcuts should be added, false otherwise.
+		 *                     If not specified, the default behavior depends upon the dialog buttons, 
+		 *                     which are used as a hint to determine whether input is required.
+		 * @return this builder
+		 * @see FXUtils#addCloseDialogShortcuts(DialogPane) 
+		 */
+		public Builder closeShortcuts(boolean addShortcuts) {
+			this.addCloseShortcuts = addShortcuts;
 			return this;
 		}
 
@@ -728,20 +752,19 @@ public class Dialogs {
 		public Builder buttons(String... buttonNames) {
 			List<ButtonType> list = new ArrayList<>();
 			for (String name : buttonNames) {
-				ButtonType type;
-				switch (name.toLowerCase()) {
-				case "ok": type = ButtonType.OK; break;
-				case "yes": type = ButtonType.YES; break;
-				case "no": type = ButtonType.NO; break;
-				case "cancel": type = ButtonType.CANCEL; break;
-				case "apply": type = ButtonType.APPLY; break;
-				case "close": type = ButtonType.CLOSE; break;
-				case "finish": type = ButtonType.FINISH; break;
-				case "next": type = ButtonType.NEXT; break;
-				case "previous": type = ButtonType.PREVIOUS; break;
-				default: type = new ButtonType(name); break;
-				}
-				list.add(type);
+				ButtonType type = switch (name.toLowerCase()) {
+                    case "ok" -> ButtonType.OK;
+                    case "yes" -> ButtonType.YES;
+                    case "no" -> ButtonType.NO;
+                    case "cancel" -> ButtonType.CANCEL;
+                    case "apply" -> ButtonType.APPLY;
+                    case "close" -> ButtonType.CLOSE;
+                    case "finish" -> ButtonType.FINISH;
+                    case "next" -> ButtonType.NEXT;
+                    case "previous" -> ButtonType.PREVIOUS;
+                    default -> new ButtonType(name);
+                };
+                list.add(type);
 			}
 			this.buttons = list;
 			return this;
@@ -839,7 +862,22 @@ public class Dialogs {
 				dialog.getDialogPane().setPrefHeight(prefHeight);
 			if (buttons != null)
 				dialog.getDialogPane().getButtonTypes().setAll(buttons);
-			
+
+			boolean addQuickClose;
+			if (addCloseShortcuts == null) {
+				// Default to quick close if we have no buttons, or a single OK, CANCEL or CLOSE button
+				var actualButtons = dialog.getDialogPane().getButtonTypes();
+				addQuickClose = actualButtons.isEmpty() ||
+						(actualButtons.size() == 1 
+								&& Set.of(ButtonType.OK, ButtonType.CANCEL, ButtonType.CLOSE).contains(actualButtons.getFirst()));
+			} else {
+				addQuickClose = addCloseShortcuts;
+			}
+			if (addQuickClose) {
+				logger.trace("Adding close dialog shortcuts");
+				FXUtils.addCloseDialogShortcuts(dialog.getDialogPane());
+			}
+
 			// We do need to be able to close the dialog somehow
 			if (dialog.getDialogPane().getButtonTypes().isEmpty()) {
 				dialog.getDialogPane().getScene().getWindow().setOnCloseRequest(e -> dialog.hide());

--- a/src/main/java/qupath/fx/utils/FXUtils.java
+++ b/src/main/java/qupath/fx/utils/FXUtils.java
@@ -21,6 +21,7 @@ import javafx.beans.binding.Bindings;
 import javafx.beans.binding.DoubleBinding;
 import javafx.beans.property.*;
 import javafx.beans.value.ObservableValue;
+import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
 import javafx.geometry.Rectangle2D;
 import javafx.scene.Node;
@@ -614,11 +615,11 @@ public class FXUtils {
 
     /**
      * Add shortcuts to close a window using the standard shortcuts (Shortcut+W, Esc).
-     * @param stage
-     * @see #addCloseWindowShortcuts(Stage, Collection)
+     * @param window
+     * @see #addCloseWindowShortcuts(Window, Collection)
      */
-    public static void addCloseWindowShortcuts(Stage stage) {
-        addCloseWindowShortcuts(stage, Arrays.asList(
+    public static void addCloseWindowShortcuts(Window window) {
+        addCloseWindowShortcuts(window, Arrays.asList(
                 new KeyCodeCombination(KeyCode.W, KeyCodeCombination.SHORTCUT_DOWN),
                 new KeyCodeCombination(KeyCode.ESCAPE)
         ));
@@ -627,21 +628,66 @@ public class FXUtils {
     /**
      * Add shortcuts to close a window using the specified key combinations.
      * These are applied as key released events, so they will not interfere with text input.
-     * @param stage
+     * @param window
      * @param keyCombinations
-     * @see #addCloseWindowShortcuts(Stage)
+     * @see #addCloseWindowShortcuts(Window)
      * @implSpec this only fires a window close request; any handler may still choose to consume the event quietly
      */
-    public static void addCloseWindowShortcuts(Stage stage, Collection<? extends KeyCombination> keyCombinations) {
+    public static void addCloseWindowShortcuts(Window window, Collection<? extends KeyCombination> keyCombinations) {
         if (keyCombinations.isEmpty()) {
             logger.warn("Empty list of close window shortcuts - ignoring request");
             return;
         }
-        stage.addEventHandler(KeyEvent.KEY_RELEASED, e -> {
+        window.addEventHandler(KeyEvent.KEY_RELEASED, e -> {
             if (e.isConsumed())
                 return;
             if (keyCombinations.stream().anyMatch(kc -> kc.match(e))) {
-                stage.fireEvent(new WindowEvent(stage, WindowEvent.WINDOW_CLOSE_REQUEST));
+                window.fireEvent(new WindowEvent(window, WindowEvent.WINDOW_CLOSE_REQUEST));
+            }
+        });
+    }
+
+    /**
+     * Add shortcuts to close a dialog using the standard shortcuts (Shortcut+W, Esc).
+     * <p>
+     * If the dialog contains a button for {@link ButtonType#CANCEL} then this will be fired,
+     * otherwise a window close request will be fired.
+     * @param dialog
+     * @see #addCloseDialogShortcuts(DialogPane, Collection)
+     */
+    public static void addCloseDialogShortcuts(DialogPane dialog) {
+        addCloseDialogShortcuts(dialog, Arrays.asList(
+                new KeyCodeCombination(KeyCode.W, KeyCodeCombination.SHORTCUT_DOWN),
+                new KeyCodeCombination(KeyCode.ESCAPE)
+        ));
+    }
+
+    /**
+     * Add shortcuts to close a dialog using the specified key combinations.
+     * These are applied as key released events, so they will not interfere with text input.
+     * <p>
+     * If the dialog contains a button for {@link ButtonType#CANCEL} then this will be fired,
+     * otherwise a window close request will be fired.
+     * @param dialog
+     * @param keyCombinations
+     * @see #addCloseWindowShortcuts(Window)
+     * @implSpec this only fires a window close request; any handler may still choose to consume the event quietly
+     */
+    public static void addCloseDialogShortcuts(DialogPane dialog, Collection<? extends KeyCombination> keyCombinations) {
+        if (keyCombinations.isEmpty()) {
+            logger.warn("Empty list of close dialog shortcuts - ignoring request");
+            return;
+        }
+        dialog.addEventHandler(KeyEvent.KEY_RELEASED, e -> {
+            var window = FXUtils.getWindow(dialog);
+            if (e.isConsumed() || window == null)
+                return;
+            if (keyCombinations.stream().anyMatch(kc -> kc.match(e))) {
+                var btnCancel = dialog.lookupButton(ButtonType.CANCEL);
+                if (btnCancel != null)
+                    btnCancel.fireEvent(new ActionEvent(e, btnCancel));
+                else
+                    window.fireEvent(new WindowEvent(window, WindowEvent.WINDOW_CLOSE_REQUEST));
             }
         });
     }


### PR DESCRIPTION
Helps address https://github.com/qupath/qupath/issues/2107

This changes `FXUtils.addCloseWindowShortcuts(Stage)` to become `FXUtils.addCloseWindowShortcuts(Window)` so that it's more general.

But it's still not general enough for a `Dialog`, since this isn't a subclass of `Window` either. So it adds `FXUtils.addCloseDialogShortcuts(DialogPane)` as well.

`Dialog.Builder` is then updated to have a `closeShortcuts(boolean addShortcuts)` method so that it's possible to specify that the shortcuts are or are not added.

The impact is mostly for `Ctrl+W` or `Cmd+W`, since `Esc` already seems to work.

If the shortcuts aren't specified, they are added by default for all dialogs that have no buttons, or that have a single button that is `OK`, `Cancel` or `Close`.

The behavior is to press the `Cancel` button is present, or fire a window close request otherwise.